### PR TITLE
Add simple 3D viewer

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,11 +2,16 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <title>E-commerce</title>
+  <title>Catálogo de Artes</title>
+  <style>
+    #catalog img { width: 100px; margin: 10px; }
+  </style>
 </head>
 <body>
-  <h1>Loja Virtual</h1>
-  <ul id="product-list"></ul>
-  <script src="app.js"></script>
+  <h1>Catálogo de Artes para Caneca</h1>
+  <div id="catalog">
+    <a href="viewer.html?art=red"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC" alt="Arte Vermelha"></a>
+    <a href="viewer.html?art=blue"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC" alt="Arte Azul"></a>
+  </div>
 </body>
 </html>

--- a/frontend/src/viewer.html
+++ b/frontend/src/viewer.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <title>Visualização 3D</title>
+  <style>
+    body, html { margin: 0; height: 100%; }
+    #viewer { width: 100%; height: 100%; display: block; }
+  </style>
+</head>
+<body>
+  <canvas id="viewer"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="viewer.js"></script>
+</body>
+</html>

--- a/frontend/src/viewer.js
+++ b/frontend/src/viewer.js
@@ -1,0 +1,40 @@
+const params = new URLSearchParams(window.location.search);
+const artKey = params.get('art') || 'red';
+
+const textures = {
+  red: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC',
+  blue: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC'
+};
+
+const art = textures[artKey] || artKey;
+
+const canvas = document.getElementById('viewer');
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
+camera.position.set(0, 1.5, 3);
+
+const controls = new THREE.OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+
+const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+scene.add(light);
+
+const loader = new THREE.TextureLoader();
+loader.load(art, texture => {
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  const geometry = new THREE.CylinderGeometry(1, 1, 1.5, 64, 1, true);
+  const material = new THREE.MeshStandardMaterial({ map: texture, side: THREE.DoubleSide });
+  const mug = new THREE.Mesh(geometry, material);
+  scene.add(mug);
+  animate();
+});
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}


### PR DESCRIPTION
## Summary
- add example PNG images for art catalog
- create catalog page listing available arts
- create viewer page with Three.js and OrbitControls
- allow viewing selected art wrapped around a mug
- embed sample images directly in HTML and JS to avoid binary files

## Testing
- `node backend/src/index.js` *(fails: Cannot find module 'express')*
- `npm start` in backend *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684b30e32558832a872ca6864188bf53