### PR TITLE
Add 3D mug builder page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Este repositório contém uma estrutura simples para iniciar um projeto de e-com
 ## Estrutura
 
 - `backend/` - Servidor Express simples que disponibiliza produtos em `/products` e serve o frontend estático.
-- `frontend/` - Contém arquivos estáticos HTML e JavaScript para consumir o backend.
+- `frontend/` - Contém arquivos estáticos HTML e JavaScript para consumir o backend. A pasta `src/builder` inclui uma página de personalização de canecas 3D.
 
 Este é apenas um ponto de partida e pode ser expandido conforme as necessidades do projeto.

--- a/frontend/src/builder/css/style.css
+++ b/frontend/src/builder/css/style.css
@@ -1,0 +1,83 @@
+body {
+  margin: 0;
+  font-family: 'Montserrat', Arial, sans-serif;
+  background: #20324A;
+  color: #E3C572;
+}
+header {
+  text-align: center;
+  margin-top: 24px;
+}
+.logo {
+  width: 90px;
+  border-radius: 100%;
+  margin-bottom: 12px;
+  background: #fff2;
+}
+h1, h2 {
+  color: #E3C572;
+}
+.catalogo {
+  margin: 24px auto;
+  max-width: 800px;
+}
+.artes {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 16px;
+}
+.artes button {
+  background: #233b5e;
+  border: 2px solid #E3C572;
+  border-radius: 12px;
+  padding: 10px 16px;
+  transition: 0.2s;
+  cursor: pointer;
+}
+.artes button:hover {
+  background: #E3C572;
+  color: #20324A;
+}
+.artes img {
+  width: 120px;
+  border-radius: 6px;
+  display: block;
+  margin-bottom: 8px;
+}
+.caneca-3d {
+  text-align: center;
+  margin: 40px auto 32px;
+}
+#viewer {
+  width: 480px;
+  height: 400px;
+  margin: 0 auto 20px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px #0005;
+}
+#whatsappBtn {
+  background: #E3C572;
+  color: #20324A;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  padding: 10px 30px;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 10px;
+  transition: 0.2s;
+}
+#whatsappBtn:hover {
+  background: #ffd700;
+}
+footer {
+  text-align: center;
+  margin-top: 32px;
+  color: #E3C57299;
+}
+@media (max-width: 600px) {
+  #viewer { width: 98vw; height: 60vw; min-height: 240px;}
+  .artes img { width: 90px; }
+}

--- a/frontend/src/builder/img/LAKERS-NBA.jpg
+++ b/frontend/src/builder/img/LAKERS-NBA.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/frontend/src/builder/img/SPFC.jpg
+++ b/frontend/src/builder/img/SPFC.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/frontend/src/builder/img/logo.jpg
+++ b/frontend/src/builder/img/logo.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/frontend/src/builder/index.html
+++ b/frontend/src/builder/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Connection Builder | Canecas 3D Personalizadas</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <img src="img/logo.jpg" class="logo" alt="Logo Connection Builder">
+    <h1>Connection Builder</h1>
+    <p>Monte sua caneca com arte exclusiva em 3D e visualize em tempo real!</p>
+  </header>
+
+  <main>
+    <section class="catalogo">
+      <h2>Escolha a arte da sua caneca</h2>
+      <div class="artes">
+        <button onclick="setTexture('img/LAKERS-NBA.jpg')">
+          <img src="img/LAKERS-NBA.jpg" alt="Arte Lakers">
+          <span>Lakers</span>
+        </button>
+        <button onclick="setTexture('img/SPFC.jpg')">
+          <img src="img/SPFC.jpg" alt="Arte SPFC">
+          <span>SPFC</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="caneca-3d">
+      <h2>Visualização 3D</h2>
+      <div id="viewer"></div>
+      <button id="whatsappBtn">Finalizar pedido pelo WhatsApp</button>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2025 Connection Builder - Canecas personalizadas em 3D</p>
+  </footer>
+
+  <!-- Three.js & loaders -->
+  <script src="https://cdn.jsdelivr.net/npm/three@0.154.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.154.0/examples/js/loaders/GLTFLoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.154.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/frontend/src/builder/js/main.js
+++ b/frontend/src/builder/js/main.js
@@ -1,0 +1,66 @@
+// Parâmetros do WhatsApp
+const numeroWhatsApp = '5511993360112';
+
+let selectedArt = 'img/LAKERS-NBA.jpg'; // Padrão
+document.getElementById('whatsappBtn').onclick = function () {
+  let texto = encodeURIComponent(
+    `Olá, quero uma caneca personalizada com a arte: ${selectedArt.split('/').pop()}`
+  );
+  window.open(`https://wa.me/${numeroWhatsApp}?text=${texto}`, '_blank');
+};
+
+// THREE.JS + GLTFLoader para caneca
+let scene, camera, renderer, controls, mug, textureLoader;
+
+function setTexture(path) {
+  selectedArt = path;
+  if (!mug) return;
+  textureLoader.load(path, function(tex) {
+    mug.traverse(function(child){
+      if (child.isMesh) {
+        child.material.map = tex;
+        child.material.needsUpdate = true;
+      }
+    });
+  });
+}
+
+function init3D() {
+  const container = document.getElementById('viewer');
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0xffffff);
+
+  camera = new THREE.PerspectiveCamera(40, container.clientWidth / container.clientHeight, 0.1, 100);
+  camera.position.set(0, 0.1, 2);
+
+  renderer = new THREE.WebGLRenderer({antialias:true, alpha:true});
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  // Luzes
+  scene.add(new THREE.AmbientLight(0xffffff, 0.7));
+  let dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+  dirLight.position.set(5, 10, 7);
+  scene.add(dirLight);
+
+  controls = new THREE.OrbitControls(camera, renderer.domElement);
+
+  // Load Modelo
+  let loader = new THREE.GLTFLoader();
+  loader.load('model/11oz-Mug.glb', function(gltf){
+    mug = gltf.scene;
+    mug.scale.set(1,1,1);
+    scene.add(mug);
+    setTexture(selectedArt);
+    animate();
+  });
+  textureLoader = new THREE.TextureLoader();
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+  controls.update();
+}
+
+window.onload = init3D;

--- a/frontend/src/builder/model/11oz-Mug.glb
+++ b/frontend/src/builder/model/11oz-Mug.glb
@@ -1,0 +1,1 @@
+placeholder model


### PR DESCRIPTION
## Summary
- create a new `builder` folder with a 3D mug customization page
- document the new page in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c603b4c28832a924dea48d9f6774e